### PR TITLE
[1] A Single injector is used for all editors (per editorPart ID)

### DIFF
--- a/example/client/src/main.ts
+++ b/example/client/src/main.ts
@@ -33,7 +33,9 @@ import { getParameters } from "./url-parameters";
 const urlParameters = getParameters();
 const filePath = urlParameters.path;
 
-const port = 8081;
+// In the Eclipse Integration, port is dynamic, as multiple editors
+// and/or Eclipse Servers may be running in parallel (e.g. 1/Eclipse IDE)
+const port = parseInt(urlParameters.port);
 const id = "workflow";
 const name = "Workflow Diagram";
 const websocket = new WebSocket(`ws://localhost:${port}/${id}`);

--- a/plugins/org.eclipse.glsp.ide.editor/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.glsp.ide.editor/META-INF/MANIFEST.MF
@@ -25,7 +25,7 @@ Require-Bundle: org.eclipse.ui.ide;bundle-version="3.13.1",
  org.eclipse.lsp4j.websocket;bundle-version="0.8.0",
  org.eclipse.lsp4j.jsonrpc;bundle-version="0.8.0",
  org.eclipse.elk.alg.layered,
- org.eclipse.glsp.server.websocket;bundle-version="0.8.0",
+ org.eclipse.glsp.server.websocket;bundle-version="0.9.0",
  org.eclipse.glsp.server;bundle-version="0.8.0",
  org.eclipse.e4.core.contexts;bundle-version="1.8.400"
 Bundle-ClassPath: .

--- a/plugins/org.eclipse.glsp.ide.editor/src/org/eclipse/glsp/ide/editor/ExportDiagramHandler.java
+++ b/plugins/org.eclipse.glsp.ide.editor/src/org/eclipse/glsp/ide/editor/ExportDiagramHandler.java
@@ -15,43 +15,15 @@
  ********************************************************************************/
 package org.eclipse.glsp.ide.editor;
 
-import java.util.Optional;
-
-import org.eclipse.core.commands.AbstractHandler;
-import org.eclipse.core.commands.ExecutionEvent;
-import org.eclipse.core.commands.ExecutionException;
-import org.eclipse.glsp.ide.editor.ui.GLSPEditorIntegrationPlugin;
-import org.eclipse.glsp.ide.editor.utils.UIUtil;
-import org.eclipse.glsp.server.actions.ActionDispatcher;
+import org.eclipse.e4.core.contexts.IEclipseContext;
+import org.eclipse.glsp.ide.editor.handlers.EclipseActionHandler;
 import org.eclipse.glsp.server.actions.ExportSVGAction;
-import org.eclipse.glsp.server.protocol.GLSPServerException;
 
-import com.google.inject.Injector;
-
-public class ExportDiagramHandler extends AbstractHandler {
+public class ExportDiagramHandler extends EclipseActionHandler {
 
    @Override
-   public Object execute(final ExecutionEvent event) throws ExecutionException {
-
-      UIUtil.getActiveEditor(GLSPDiagramEditorPart.class).ifPresent(editorPart -> {
-         String clientId = (editorPart).getClientId();
-         ActionDispatcher actionDispatcher = getInjector(editorPart).getInstance(ActionDispatcher.class);
-
-         actionDispatcher.dispatch(clientId, new ExportSVGAction());
-
-      });
-      return null;
-   }
-
-   protected Injector getInjector(final GLSPDiagramEditorPart editorPart) {
-      Optional<Injector> injector = GLSPEditorIntegrationPlugin.getDefault().getGLSPEditorRegistry()
-         .getInjector(editorPart);
-      if (!injector.isPresent()) {
-         throw new GLSPServerException(
-            "Could not retrieve GLSP injector. GLSP editor is not properly configured: "
-               + editorPart.getEditorSite().getId());
-      }
-      return injector.get();
+   protected void execute(final IEclipseContext context) {
+      dispatchMessage(context, new ExportSVGAction());
    }
 
 }

--- a/plugins/org.eclipse.glsp.ide.editor/src/org/eclipse/glsp/ide/editor/GLSPDiagramEditorPart.java
+++ b/plugins/org.eclipse.glsp.ide.editor/src/org/eclipse/glsp/ide/editor/GLSPDiagramEditorPart.java
@@ -67,11 +67,12 @@ import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.part.EditorPart;
 
 import com.google.gson.JsonObject;
+import com.google.inject.Injector;
 
 public class GLSPDiagramEditorPart extends EditorPart {
    /**
-    * {@link IEclipseContext} key for the current client id.
-    * The associated value is a {@link String}.
+    * {@link IEclipseContext} key for the current client id. The associated value
+    * is a {@link String}.
     */
    public static final String GLSP_CLIENT_ID = "GLSP_CLIENT_ID";
    private static final AtomicInteger COUNT = new AtomicInteger(0);
@@ -88,6 +89,7 @@ public class GLSPDiagramEditorPart extends EditorPart {
    private boolean dirty;
 
    private boolean connected;
+   private Injector injector;
 
    public GLSPDiagramEditorPart() {}
 
@@ -96,7 +98,8 @@ public class GLSPDiagramEditorPart extends EditorPart {
          .getGLSPServerManager(this);
       if (!serverManager.isPresent()) {
          throw new GLSPServerException(
-            "Could not retrieve GLSPServerManager. GLSP editor is not properly configured: " + getEditorSite().getId());
+            "Could not retrieve GLSPServerManager. GLSP editor is not properly configured: "
+               + getEditorSite().getId());
       }
       return serverManager.get();
    }
@@ -107,7 +110,7 @@ public class GLSPDiagramEditorPart extends EditorPart {
 
    @Override
    public void doSave(final IProgressMonitor monitor) {
-      ActionDispatcher dispatcher = getServerManager().getInjector().getInstance(ActionDispatcher.class);
+      ActionDispatcher dispatcher = getInjector().getInstance(ActionDispatcher.class);
       dispatcher.dispatch(clientId, new SaveModelAction());
    }
 
@@ -140,7 +143,6 @@ public class GLSPDiagramEditorPart extends EditorPart {
       GLSPServerManager serverManager = getServerManager();
       context.set(GLSPServerManager.class, serverManager);
       context.set(GLSP_CLIENT_ID, clientId);
-      context.set(ActionDispatcher.class, serverManager.getInjector().getInstance(ActionDispatcher.class));
       getActionProvider().ifPresent(provider -> context.set(GLSPActionProvider.class, provider));
       // Editor context contains some info about the current client state. It can
       // be updated when the client sends new actions
@@ -178,7 +180,6 @@ public class GLSPDiagramEditorPart extends EditorPart {
 
       statusBarIcon = new Label(statusBar, SWT.NONE);
       statusBarIcon.setImage(sharedImages.getImage(IMG_OBJS_INFO_TSK));
-
       statusBarMessage = new Label(statusBar, SWT.NONE);
       statusBarMessage.setText("");
 
@@ -277,10 +278,10 @@ public class GLSPDiagramEditorPart extends EditorPart {
             .map(ServerConnector.class::cast).orElse(null);
 
          if (connector != null) {
-            String url = String.format("http://%s:%s/diagram.html?client=%s&path=%s", connector.getHost(),
-               connector.getPort(), encodeParameter(getClientId()), encodeParameter(path));
-            browser.setUrl(
-               url);
+            String url = String.format("http://%s:%s/diagram.html?client=%s&path=%s&port=%s", connector.getHost(),
+               manager.getLocalPort(), encodeParameter(getClientId()), encodeParameter(path),
+               manager.getLocalPort());
+            browser.setUrl(url);
             System.out.println(url);
             this.connected = true;
 
@@ -321,7 +322,28 @@ public class GLSPDiagramEditorPart extends EditorPart {
       }
       // Update the EditorContext, as this is specific to each action.
       getSite().getService(IEclipseContext.class).set(EditorContext.class, action.getEditorContext());
-      // Nothing more to do here; populating & opening the menu will be handled directly
+      // Nothing more to do here; populating & opening the menu will be handled
+      // directly
       // by the browser control.
    }
+
+   /**
+    * This method will be invoked once the client session is established, which
+    * will happen asynchronously.
+    *
+    * @param injector
+    */
+   public void setInjector(final Injector injector) {
+      this.injector = injector;
+      IEclipseContext context = getSite().getService(IEclipseContext.class);
+      context.set(ActionDispatcher.class, injector.getInstance(ActionDispatcher.class));
+   }
+
+   /**
+    * Return the GLSP Injector associated to this editor.
+    *
+    * @return
+    *         The GLSP Injector associated to this editor.
+    */
+   public Injector getInjector() { return injector; }
 }

--- a/plugins/org.eclipse.glsp.ide.editor/src/org/eclipse/glsp/ide/editor/GLSPEditorRegistry.java
+++ b/plugins/org.eclipse.glsp.ide.editor/src/org/eclipse/glsp/ide/editor/GLSPEditorRegistry.java
@@ -26,8 +26,6 @@ import org.eclipse.glsp.ide.editor.utils.UIUtil;
 import org.eclipse.ui.IPartListener;
 import org.eclipse.ui.IWorkbenchPart;
 
-import com.google.inject.Injector;
-
 public class GLSPEditorRegistry {
    private static String EDITOR_INTEGRATION_EXTENSION_POINT = "org.eclipse.glsp.editor.integration";
    private static String SERVER_MANAGER_CLASS_ATTRIBUTE = "serverManagerClass";
@@ -72,14 +70,6 @@ public class GLSPEditorRegistry {
 
    public Optional<GLSPServerManager> getGLSPServerManager(final String editorId) {
       return Optional.of(editorIdToServerManager.get(editorId));
-   }
-
-   public Optional<Injector> getInjector(final GLSPDiagramEditorPart diagramEditorPart) {
-      return getGLSPServerManager(diagramEditorPart.getEditorId()).map(GLSPServerManager::getInjector);
-   }
-
-   public Optional<Injector> getInjector(final String clientId) {
-      return getGLSPEditor(clientId).flatMap(this::getInjector);
    }
 
    public Optional<GLSPDiagramEditorPart> getGLSPEditor(final String clientId) {

--- a/plugins/org.eclipse.glsp.ide.editor/src/org/eclipse/glsp/ide/editor/ui/GLSPDynamicContribution.java
+++ b/plugins/org.eclipse.glsp.ide.editor/src/org/eclipse/glsp/ide/editor/ui/GLSPDynamicContribution.java
@@ -19,7 +19,6 @@ import java.util.Optional;
 
 import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.glsp.ide.editor.GLSPDiagramEditorPart;
-import org.eclipse.glsp.ide.editor.GLSPServerManager;
 import org.eclipse.glsp.ide.editor.actions.GLSPActionProvider;
 import org.eclipse.glsp.server.model.GModelState;
 import org.eclipse.glsp.server.model.ModelStateProvider;
@@ -51,12 +50,12 @@ public class GLSPDynamicContribution extends ContributionItem implements IWorkbe
       IEclipseContext context = serviceLocator.getService(IEclipseContext.class);
       GLSPActionProvider actionProvider = context.get(GLSPActionProvider.class);
       if (actionProvider != null) {
-         GLSPServerManager serverManager = context.get(GLSPServerManager.class);
+         GLSPDiagramEditorPart editor = context.get(GLSPDiagramEditorPart.class);
          String clientId = (String) context.get(GLSPDiagramEditorPart.GLSP_CLIENT_ID);
          // The model state will not be stored in the EclipseContext, as we (currently) have no way
          // to hook into new client connections. The Editor UI will be created and ready before the Browser
          // connects to the Backend server; so we may not have a ModelState yet.
-         Optional<GModelState> modelState = serverManager.getInjector().getInstance(ModelStateProvider.class)
+         Optional<GModelState> modelState = editor.getInjector().getInstance(ModelStateProvider.class)
             .getModelState(clientId);
          if (modelState.isPresent()) {
             EditorContext editorContext = serviceLocator.getService(EditorContext.class);

--- a/releng/org.eclipse.glsp.ide.releng.target/r2020-09.target
+++ b/releng/org.eclipse.glsp.ide.releng.target/r2020-09.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="2020-09 - Release" sequenceNumber="1606142331">
+<target name="2020-09 - Release" sequenceNumber="1606476382">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.platform.feature.group" version="4.17.0.v20200902-1800"/>
@@ -20,11 +20,11 @@
       <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20200831200620/repository/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.glsp.feature.feature.group" version="0.8.0"/>
+      <unit id="org.eclipse.glsp.feature.feature.group" version="0.9.0.202011261324"/>
       <unit id="org.eclipse.glsp.server.websocket" version="0.0.0"/>
       <unit id="org.eclipse.glsp.layout" version="0.0.0"/>
       <unit id="org.eclipse.glsp.example.workflow" version="0.0.0"/>
-      <repository location="https://download.eclipse.org/glsp/server/p2/releases/0.8.0/"/>
+      <repository location="https://download.eclipse.org/glsp/server/p2/nightly/0.9/0.9.0.202011261324/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.jetty.bundles.f.feature.group" version="9.4.14.v20181113"/>

--- a/releng/org.eclipse.glsp.ide.releng.target/r2020-09.tpd
+++ b/releng/org.eclipse.glsp.ide.releng.target/r2020-09.tpd
@@ -16,7 +16,7 @@ location "https://download.eclipse.org/tools/orbit/downloads/drops/R202008312006
 	org.apache.commons.cli
 }
 
-location "https://download.eclipse.org/glsp/server/p2/releases/0.8.0/" {
+location "https://download.eclipse.org/glsp/server/p2/nightly/0.9/0.9.0.202011261324/" {
 	org.eclipse.glsp.feature.feature.group
 	org.eclipse.glsp.server.websocket lazy
 	org.eclipse.glsp.layout lazy


### PR DESCRIPTION
- (Unrelated) Fix the path to the plug-in to be consistent with the refactored name, in the client's copyFiles command
- An injector instance should correspond to a single client-connection, as it contains some network-specific singleton instances that are not meant to be shared/reused
- Start the server on any available port, to avoid conflicts between different languages or parallel Eclipse IDE instances